### PR TITLE
Enlarge body size limit of koa-bodyparser fix #15

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,11 @@ app.use(async (ctx, next) => {
   }
 });
 
-app.use(koaBody());
+app.use(koaBody({
+  formLimit: '1mb',
+  jsonLimit: '10mb',
+  textLimit: '10mb'
+}));
 
 router.post('/graphql', graphqlKoa(() => ({
   schema,


### PR DESCRIPTION
fix for #15 

Enlarge formLimit from 56kb to 1mb and jsonLimit from 1mb to 10mb

Actually, koa-body doesn't take "textLimit" option. But readme has this option so I use it.

https://github.com/koajs/bodyparser/search?utf8=%E2%9C%93&q=textLimit