### PR TITLE
Use more_like_this query

### DIFF
--- a/src/graphql/queries/Search.js
+++ b/src/graphql/queries/Search.js
@@ -42,9 +42,9 @@ export default {
       client.msearch({
         body: [
           { index: 'rumors', type: 'basic' },
-          { query: { match: { text: truncatedText } } },
+          { query: { more_like_this: { 'fields': ['text'], 'like': text, 'min_term_freq': 1, 'min_doc_freq': 1 } } },
           { index: 'answers', type: 'basic' },
-          { query: { match: { 'versions.text': truncatedText } } },
+          { query: { more_like_this: { 'fields': ['versions.text'], 'like': text, 'min_term_freq': 1, 'min_doc_freq': 1 } } },
         ],
       }),
       findInCrawled ?


### PR DESCRIPTION
#7 
需搭配 MrOrz/rumors-db#5 使用。

跑 `validate:sameDoc` 的結果:
```
---- Summary ----
110/124 correct
88.71 % correct.
```

看似跟調整前差不多，但我稍微檢查過，
`WRONG DOC` 和 `NOT FOUND` 幾乎都是找到重複或相似的謠言，
相信這個修改的實際效果應該會不錯。