### PR TITLE
Reduce the number of shards to 1

### DIFF
--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -4,12 +4,12 @@ Object {
     "GetArticle": Object {
       "relatedArticles": Array [
         Object {
-          "id": "foo3",
-          "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
-        },
-        Object {
           "id": "foo2",
           "text": "Lorum ipsum Lorum ipsum",
+        },
+        Object {
+          "id": "foo3",
+          "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
         },
       ],
     },
@@ -38,12 +38,12 @@ Object {
     "GetArticle": Object {
       "relatedArticles": Array [
         Object {
-          "id": "foo2",
-          "text": "Lorum ipsum Lorum ipsum",
-        },
-        Object {
           "id": "foo3",
           "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
+        },
+        Object {
+          "id": "foo2",
+          "text": "Lorum ipsum Lorum ipsum",
         },
       ],
     },

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -1,10 +1,10 @@
 exports[`Search lists all articles 1`] = `
 Array [
   Object {
-    "id": "listArticleTest2",
+    "id": "listArticleTest1",
   },
   Object {
-    "id": "listArticleTest1",
+    "id": "listArticleTest2",
   },
   Object {
     "id": "listArticleTest3",

--- a/test/rumors-db/db/loadSchema.js
+++ b/test/rumors-db/db/loadSchema.js
@@ -13,6 +13,7 @@ Object.keys(schema).forEach((index) => {
   client.indices.create({
     index,
     body: {
+      settings: { number_of_shards: 1 },
       mappings: { basic: schema[index] },
     },
   }).then(() => {


### PR DESCRIPTION
因為目前資料並不多，沒有拆多個 shard 的必要，
並且因為每個 shard 的 TF-IDF 是分開來算的，這樣設定對於 query performance 也會有幫助。