### PR TITLE
fix `replyIds` to `replyConnectionIds`

### DIFF
--- a/src/graphql/models/SearchResult.js
+++ b/src/graphql/models/SearchResult.js
@@ -54,9 +54,9 @@ export default new GraphQLObjectType({
         articles: scoredArticles, replies: scoredReplies, crawledDocs: scoredCrawledDocs,
       }) {
         const bestScoredArticle = theBestDoc(scoredArticles.filter(
-          article => article.doc.replyIds && article.doc.replyIds.length,
+          article => article.doc.replyConnectionIds && article.doc.replyConnectionIds.length,
         ), 13);
-        if (bestScoredArticle && bestScoredArticle.doc.replyIds.length) {
+        if (bestScoredArticle && bestScoredArticle.doc.replyConnectionIds.length) {
           return {
             ...bestScoredArticle.doc, _type: 'ARTICLE',
           };


### PR DESCRIPTION
跑 evaluate 的時候發現結果錯得有點離譜,
debug 之後發現是 SearchResult.js 裡面
`replyIds` 沒有被改成 `replyConnectionIds`